### PR TITLE
Jasmine 2.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Jasmine Test Helpers
+Jasmine Node Helpers
 ====================
 
 *Helping you test your [Node.js] applications, one helper at a time.*
@@ -18,7 +18,7 @@ How to Use
 
 Include the package in your `package.json` file.
 
-    npm install --save-dev jasmine-test-helpers
+    npm install --save-dev jasmine-node-helpers
 
 Then you need to be able to include the helper in your testing directory or where you'd like to run tests.
 
@@ -28,10 +28,10 @@ If you don't already have a helpers object in `spec/support/jasmine.json`, add t
 
 
     "helpers": [
-        "node_modules/jasmine-test-helpers/lib/*"
+        "node_modules/jasmine-node-helpers/lib/*"
     ]
 
-If you already have a helpers object, just add `"node_modules/jasmine-test-helpers/lib/*"` to it.
+If you already have a helpers object, just add `"node_modules/jasmine-node-helpers/lib/*"` to it.
 
 `jasmine.fail([actual], [expected])`
 ------------------------------------
@@ -113,13 +113,13 @@ This makes it much easier to use promises in node tests. Instead of having to re
 
 See how much simpler that is? You won't need to add `done` to the `it` or accidentally put `done` in the `describe` and wonder why your tests are failing when you've been writing tests all day.
 
-[Code Coverage]: https://codecov.io/github/tests-always-included/jasmine-test-helpers?branch=master
-[codecov-image]: https://codecov.io/github/tests-always-included/jasmine-test-helpers/coverage.svg?branch=master
-[Dev Dependencies]: https://david-dm.org/tests-always-included/jasmine-test-helpers/master#info=devDependencies
-[devdependencies-image]: https://david-dm.org/tests-always-included/jasmine-test-helpers/master/dev-status.png
-[Dependencies]: https://david-dm.org/tests-always-included/jasmine-test-helpers/master
-[dependencies-image]: https://david-dm.org/tests-always-included/jasmine-test-helpers/master.png
+[Code Coverage]: https://codecov.io/github/tests-always-included/jasmine-node-helpers?branch=master
+[codecov-image]: https://codecov.io/github/tests-always-included/jasmine-node-helpers/coverage.svg?branch=master
+[Dev Dependencies]: https://david-dm.org/tests-always-included/jasmine-node-helpers/master#info=devDependencies
+[devdependencies-image]: https://david-dm.org/tests-always-included/jasmine-node-helpers/master/dev-status.png
+[Dependencies]: https://david-dm.org/tests-always-included/jasmine-node-helpers/master
+[dependencies-image]: https://david-dm.org/tests-always-included/jasmine-node-helpers/master.png
 [Jasmine]: https://jasmine.github.io/
 [Node.js]: https://nodejs.org
-[travis-image]: https://secure.travis-ci.org/tests-always-included/jasmine-test-helpers.png
-[Travis CI]: http://travis-ci.org/tests-always-included/jasmine-test-helpers
+[travis-image]: https://secure.travis-ci.org/tests-always-included/jasmine-node-helpers.png
+[Travis CI]: http://travis-ci.org/tests-always-included/jasmine-node-helpers

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Jasmine-Node Helpers
+Jasmine Helpers
 ====================
 
 *Helping you test your [Node.js] applications, one helper at a time.*
@@ -11,9 +11,7 @@ Jasmine-Node Helpers
 About
 -----
 
-This contains a series of [Jasmine] 1.3 helpers when using [Jasmine-Node] to facilitate testing certain functionality more easily. These help to detect when a test fails but should have passed, turn middleware into a promise and makes it easier to use promises in tests. More explanation is below for each helper.
-
-*Note: If you are not using [Jasmine-Node] these helpers aren't going to help your testing suite very much.*
+This contains a series of [Jasmine] 2.4.1 helpers made to facilitate testing certain functionality more easily. These help to detect when a test fails but should have passed, turn middleware into a promise and makes it easier to use promises in tests. More explanation is below for each helper.
 
 How to Use
 ----------
@@ -24,16 +22,16 @@ Include the package in your `package.json` file.
 
 Then you need to be able to include the helper in your testing directory or where you'd like to run tests.
 
-You can do this by creating a symbolic link to files contained. You'll want to link to the files and not the folder. [Jasmine] doesn't seem to pick up on the files if only the folder is linked. Below is an example of setting up a symbolic link. Make sure to include the folder in your `.gitignore` file so you don't commit the files as this folder will show up in your status.
+You can do this by creating a helpers object in your `spec/support/jasmine.json` file, or adding to an existing helpers object.
 
-    // Linux/MacOS
-    mkdir ./path/to/project/test-folder/jasmine-node-helpers
+If you don't already have a helpers object in `spec/support/jasmine.json`, add this:
 
-    cd /path/to/project
-    ln -s ./node_modules/jasmine-node-helpers/lib/* ./test-folder/jasmine-node-helpers/
 
-    // Windows
-    // If you can figure out how to make symlink work, good on you, make a [fork](CONTRIBUTING.md) and update those instructions please.
+    "helpers": [
+        "node_modules/jasmine-test-helpers/lib/*"
+    ]
+
+If you already have a helpers object, just add `"node_modules/jasmine-test-helpers/lib/*"` to it.
 
 `jasmine.fail([actual], [expected])`
 ------------------------------------
@@ -115,14 +113,13 @@ This makes it much easier to use promises in node tests. Instead of having to re
 
 See how much simpler that is? You won't need to add `done` to the `it` or accidentally put `done` in the `describe` and wonder why your tests are failing when you've been writing tests all day.
 
-[Code Coverage]: https://codecov.io/github/tests-always-included/jasmine-node-helpers?branch=master
-[codecov-image]: https://codecov.io/github/tests-always-included/jasmine-node-helpers/coverage.svg?branch=master
-[Dev Dependencies]: https://david-dm.org/tests-always-included/jasmine-node-helpers/master#info=devDependencies
-[devdependencies-image]: https://david-dm.org/tests-always-included/jasmine-node-helpers/master/dev-status.png
-[Dependencies]: https://david-dm.org/tests-always-included/jasmine-node-helpers/master
-[dependencies-image]: https://david-dm.org/tests-always-included/jasmine-node-helpers/master.png
+[Code Coverage]: https://codecov.io/github/tests-always-included/jasmine-test-helpers?branch=master
+[codecov-image]: https://codecov.io/github/tests-always-included/jasmine-test-helpers/coverage.svg?branch=master
+[Dev Dependencies]: https://david-dm.org/tests-always-included/jasmine-test-helpers/master#info=devDependencies
+[devdependencies-image]: https://david-dm.org/tests-always-included/jasmine-test-helpers/master/dev-status.png
+[Dependencies]: https://david-dm.org/tests-always-included/jasmine-test-helpers/master
+[dependencies-image]: https://david-dm.org/tests-always-included/jasmine-test-helpers/master.png
 [Jasmine]: https://jasmine.github.io/
-[Jasmine-Node]: https://www.npmjs.com/package/jasmine-node
 [Node.js]: https://nodejs.org
-[travis-image]: https://secure.travis-ci.org/tests-always-included/jasmine-node-helpers.png
-[Travis CI]: http://travis-ci.org/tests-always-included/jasmine-node-helpers
+[travis-image]: https://secure.travis-ci.org/tests-always-included/jasmine-test-helpers.png
+[Travis CI]: http://travis-ci.org/tests-always-included/jasmine-test-helpers

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Jasmine Helpers
+Jasmine Test Helpers
 ====================
 
 *Helping you test your [Node.js] applications, one helper at a time.*
@@ -88,7 +88,7 @@ The middleware can be written in a traditional style using a callback like `done
         });
     });
 
-Promises helper
+Promises Helper
 ---------------
 
 This makes it much easier to use promises in node tests. Instead of having to remember to pass `done` in the `it` part of the testing in [Jasmine], you simple need to return the promise and the rest is handled like normal.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you don't already have a helpers object in `spec/support/jasmine.json`, add t
 
 
     "helpers": [
-        "node_modules/jasmine-node-helpers/lib/*"
+        "../node_modules/jasmine-node-helpers/lib/*"
     ]
 
 If you already have a helpers object, just add `"node_modules/jasmine-node-helpers/lib/*"` to it.

--- a/lib/promises.helper.js
+++ b/lib/promises.helper.js
@@ -43,7 +43,7 @@ function handlePromise(parameterIndex, original) {
     return fn;
 }
 
-prototype = jasmine.Env.prototype;
+prototype = jasmine.getEnv();
 
 if (!prototype.patchedForPromises) {
     prototype.patchedForPromises = true;

--- a/lib/promises.helper.js
+++ b/lib/promises.helper.js
@@ -49,7 +49,7 @@ if (!prototype.patchedForPromises) {
     prototype.patchedForPromises = true;
     prototype.afterEach = handlePromise(0, prototype.afterEach);
     prototype.beforeEach = handlePromise(0, prototype.beforeEach);
-    prototype.iit = handlePromise(1, prototype.iit);
+    prototype.fit = handlePromise(1, prototype.fit);
     prototype.it = handlePromise(1, prototype.it);
     prototype.xit = handlePromise(1, prototype.xit);
 }

--- a/lib/promises.helper.js
+++ b/lib/promises.helper.js
@@ -43,13 +43,25 @@ function handlePromise(parameterIndex, original) {
     return fn;
 }
 
-prototype = jasmine.getEnv();
+if (Object.keys(jasmine.Env.prototype).length === 0) {
+    version = 2;
+    prototype = jasmine.getEnv();
+} else {
+    version = 1;
+    prototype = jasmine.Env.prototype;
+}
 
 if (!prototype.patchedForPromises) {
     prototype.patchedForPromises = true;
     prototype.afterEach = handlePromise(0, prototype.afterEach);
     prototype.beforeEach = handlePromise(0, prototype.beforeEach);
-    prototype.fit = handlePromise(1, prototype.fit);
+
+    if (version >= 2) {
+        prototype.fit = handlePromise(1, prototype.fit);
+    } else {
+        prototype.iit = handlePromise(1, prototype.iit);
+    }
+
     prototype.it = handlePromise(1, prototype.it);
     prototype.xit = handlePromise(1, prototype.xit);
 }

--- a/spec/promises.helper.spec.js
+++ b/spec/promises.helper.spec.js
@@ -30,11 +30,11 @@ describe("promises.helper", () => {
         });
     });
     it("has patched the methods", () => {
-        expect(jasmine.Env.prototype.patchedForPromises).toBe(true);
-        expect(jasmine.Env.prototype.afterEach.patchedForPromises).toBe(true);
-        expect(jasmine.Env.prototype.beforeEach.patchedForPromises).toBe(true);
-        expect(jasmine.Env.prototype.iit.patchedForPromises).toBe(true);
-        expect(jasmine.Env.prototype.it.patchedForPromises).toBe(true);
-        expect(jasmine.Env.prototype.xit.patchedForPromises).toBe(true);
+        expect(jasmine.getEnv().patchedForPromises).toBe(true);
+        expect(jasmine.getEnv().afterEach.patchedForPromises).toBe(true);
+        expect(jasmine.getEnv().beforeEach.patchedForPromises).toBe(true);
+        expect(jasmine.getEnv().fit.patchedForPromises).toBe(true);
+        expect(jasmine.getEnv().it.patchedForPromises).toBe(true);
+        expect(jasmine.getEnv().xit.patchedForPromises).toBe(true);
     });
 });


### PR DESCRIPTION
Allows helpers to be used in a project that is testing with Jasmine 2.4.1. This is not backwards compatible with Jasmine 1.3.
